### PR TITLE
Implement replacement for libacl acl_to_xattr()

### DIFF
--- a/cvmfs/CMakeLists.txt
+++ b/cvmfs/CMakeLists.txt
@@ -572,6 +572,7 @@ if (BUILD_SERVER)
   # /usr/bin/cvmfs_swissknife[_debug]
   #
   set (CVMFS_SWISSKNIFE_SOURCES
+       acl.cc
        backoff.cc
        catalog.cc
        catalog_counters.cc

--- a/cvmfs/acl.cc
+++ b/cvmfs/acl.cc
@@ -1,0 +1,362 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include "cvmfs_config.h"
+#include "acl.h"
+
+#include <cassert>
+#include <cstring>
+#include <vector>
+#include <algorithm>
+
+#include <string.h>
+
+#include "util/posix.h"
+
+using namespace std;  // NOLINT
+
+#ifdef COMPARE_TO_LIBACL
+#include "acl/libacl.h"
+#else // COMPARE_TO_LIBACL
+
+// ACL permission bits
+#define ACL_READ (0x04)
+#define ACL_WRITE (0x02)
+#define ACL_EXECUTE (0x01)
+
+// ACL tag types
+#define ACL_UNDEFINED_TAG (0x00)
+#define ACL_USER_OBJ (0x01)
+#define ACL_USER (0x02)
+#define ACL_GROUP_OBJ (0x04)
+#define ACL_GROUP (0x08)
+#define ACL_MASK (0x10)
+#define ACL_OTHER (0x20)
+
+// ACL qualifier constants
+#define ACL_UNDEFINED_ID ((id_t) - 1)
+
+#endif // COMPARE_TO_LIBACL
+
+#define ACL_EA_VERSION 0x0002
+
+// ACL data structures
+struct acl_ea_entry {
+  u_int16_t e_tag;
+  u_int16_t e_perm;
+  u_int32_t e_id;
+
+  // implements sorting compatible with libacl
+  bool operator<(const acl_ea_entry& other) const {
+    if (e_tag != other.e_tag) {
+      return e_tag < other.e_tag;
+    }
+    return e_id < other.e_id;
+  }
+};
+
+struct acl_ea_header {
+  u_int32_t a_version;
+  acl_ea_entry a_entries[0];
+};
+
+static int acl_from_text_to_string_entries(const string &acl_string, vector<string> &string_entries)
+{
+  std::size_t entry_pos = 0;
+  while (entry_pos != string::npos) {
+    size_t entry_length;
+    size_t next_pos;
+    size_t sep_pos = acl_string.find_first_of(",\n", entry_pos);
+    if (sep_pos == string::npos) {
+      if (acl_string.length() > entry_pos) {
+        entry_length = acl_string.length() - entry_pos;
+        next_pos = string::npos;
+      } else {
+        // we've just looked past a trailing delimiter
+        break;
+      }
+    } else {
+      assert(sep_pos >= entry_pos);
+      entry_length = sep_pos - entry_pos;
+      next_pos = sep_pos + 1;
+    }
+    if (entry_length == 0) {
+      // libacl tolerates excessive whitespace but not excessive delimiters.
+      // It's simpler for us to treat whitespace as delimiters.
+      entry_pos = next_pos;
+      continue;
+    }
+    string entry(acl_string, entry_pos, entry_length);
+    entry_pos = next_pos;
+
+    // search for '#'-starting comment, discard if found
+    size_t comment_pos = entry.find('#');
+    if (comment_pos != string::npos) {
+      entry = string(entry, 0, comment_pos);
+    }
+
+    // TODO trim whitespace on both ends
+
+    // discard empty lines
+    if (entry.length() == 0) {
+      continue;
+    }
+
+    string_entries.push_back(entry);
+  }
+  return 0;
+}
+
+static int acl_parms_from_text(const string &str, u_int16_t *perms)
+{
+  // Currently unsupported syntax features found in setfacl:
+  // - X (capital x)
+  // - numeric syntax
+  // See "man 1 setfacl", "The perms field is..."
+
+  *perms = 0;
+  for (const char &c : str) {
+    switch(c) {
+      case 'r': *perms |= ACL_READ; break;
+      case 'w': *perms |= ACL_WRITE; break;
+      case 'x': *perms |= ACL_EXECUTE; break;
+      case '-': break;
+      default: return EINVAL;
+    }
+  }
+  return 0;
+}
+
+static int acl_entry_from_text(const string &str, acl_ea_entry &entry)
+{
+  // break down to 3 fields by ':'
+  // type:qualifier:permissions according to terminology
+  // e_tag:e_id:e_perm are acl_ea_entry field names
+  size_t sep_pos = str.find(':');
+  if (sep_pos == string::npos) {
+    return EINVAL;
+  }
+  string type(str, 0, sep_pos);
+  size_t next_field_pos = sep_pos + 1;
+  sep_pos = str.find(':', next_field_pos);
+  if (sep_pos == string::npos) {
+    return EINVAL;
+  }
+  string qualifier(str, next_field_pos, sep_pos - next_field_pos);
+  next_field_pos = sep_pos + 1;
+  string permissions(str, next_field_pos);
+
+  if (!type.compare("user") || !type.compare("u")) {
+    entry.e_tag = qualifier.empty() ? ACL_USER_OBJ : ACL_USER;
+  } else if (!type.compare("group") || !type.compare("g")) {
+    entry.e_tag = qualifier.empty() ? ACL_GROUP_OBJ : ACL_GROUP;
+  } else if (!type.compare("other") || !type.compare("o")) {
+    entry.e_tag = ACL_OTHER;
+  } else if (!type.compare("mask") || !type.compare("m")) {
+    entry.e_tag = ACL_MASK;
+  } else {
+    return EINVAL;
+  }
+  entry.e_tag = htole16(entry.e_tag);
+
+  if (qualifier.empty()) {
+    entry.e_id = ACL_UNDEFINED_ID;
+  } else {
+    char* at_null_terminator_if_number;
+    long number = strtol(qualifier.c_str(), &at_null_terminator_if_number, 10);
+    if (*at_null_terminator_if_number != '\0') {
+      bool ok;
+      if (entry.e_tag == htole16(ACL_USER)) {
+        [[maybe_unused]] gid_t main_gid;
+        uid_t uid;
+        ok = GetUidOf(qualifier, &uid, &main_gid);
+        number = uid;
+      } else if (entry.e_tag == htole16(ACL_GROUP)) {
+        gid_t gid;
+        ok = GetGidOf(qualifier, &gid);
+        number = gid;
+      } else {
+        assert(false);
+      }
+      if (!ok) {
+        return EINVAL;
+      }
+    }
+    entry.e_id = htole32(number);
+  }
+
+  // parse perms
+  u_int16_t host_byteorder_perms;
+  int ret;
+  ret = acl_parms_from_text(permissions, &host_byteorder_perms);
+  if (ret) {
+    return ret;
+  }
+  entry.e_perm = htole16(host_byteorder_perms);
+
+  return 0;
+}
+
+static bool acl_valid_builtin(const vector<acl_ea_entry> &entries)
+{
+  // From man acl_valid:
+  // The three required entries ACL_USER_OBJ, ACL_GROUP_OBJ, and ACL_OTHER must
+  // exist exactly once in the ACL.
+  //
+  // If the ACL contains any ACL_USER or ACL_GROUP entries, then an ACL_MASK
+  // entry is also required.
+  //
+  // The ACL may contain at most one ACL_MASK entry.
+  //
+  // The user identifiers must be unique among all entries of type ACL_USER.
+  // The group identifiers must be unique among all entries of type ACL_GROUP.
+
+  bool types_met[ACL_OTHER + 1] = {false, };
+
+  for (auto entry_it = entries.begin(); entry_it != entries.end(); ++entry_it) {
+    const acl_ea_entry &e = *entry_it;
+    assert(e.e_tag <= ACL_OTHER);
+    bool &type_met = types_met[e.e_tag];
+    switch (e.e_tag) {
+      // at most one of these types
+      case ACL_USER_OBJ:
+      case ACL_GROUP_OBJ:
+      case ACL_OTHER:
+      case ACL_MASK:
+        if (type_met) {
+          return false;
+        } else {
+          type_met = true;
+        }
+        break;
+      case ACL_USER:
+      case ACL_GROUP:
+        type_met = true;
+        break;
+      default:
+        assert(false);
+    }
+  }
+  if (!(types_met[ACL_USER_OBJ] && types_met[ACL_GROUP_OBJ] && types_met[ACL_OTHER])) {
+    return false;
+  }
+  if ((types_met[ACL_USER] || types_met[ACL_GROUP]) && !types_met[ACL_MASK]) {
+    return false;
+  }
+  // TODO ACL_USER, ACL_GROUP uniqueness checks. autkin figures it's not a pressing issue.
+  return true;
+}
+
+int acl_from_text_to_xattr_value(const string textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode)
+{
+  int ret;
+
+  o_equiv_mode = true;
+
+  // get individual textual entries from one big text
+  vector<string> string_entries;
+  ret = acl_from_text_to_string_entries(textual_acl, string_entries);
+  if (ret) {
+    return ret;
+  }
+
+  // get individual entries in structural form
+  vector<acl_ea_entry> entries;
+  for (auto string_it = string_entries.begin(); string_it != string_entries.end(); ++string_it) {
+    acl_ea_entry entry;
+    ret = acl_entry_from_text(*string_it, entry);
+    if (ret) {
+      return ret;
+    }
+    if (entry.e_tag == ACL_GROUP || entry.e_tag == ACL_USER) {
+      o_equiv_mode = false;
+    }
+    entries.push_back(entry);
+  }
+
+  // sort entries as libacl does, to be able to use it in testing as a reference
+  sort(entries.begin(), entries.end());
+
+  // reject what acl_valid() rejects, to be able to use it in testing
+  if (!acl_valid_builtin(entries)) {
+    return EINVAL;
+  }
+
+  // if nothing but usual u,g,o bits, don't produce a binary. Mimicing libacl.
+  if (o_equiv_mode) {
+    o_binary_acl = NULL;
+    o_size = 0;
+    return 0;
+  }
+
+  // get one big buffer with all the entries in the "on-disk" xattr format
+  size_t acl_entry_count = entries.size();
+  size_t buf_size = sizeof(acl_ea_header) + (acl_entry_count * sizeof(acl_ea_entry));
+  char *buf = (char*) malloc(buf_size);
+  if (!buf) {
+    return ENOMEM;
+  }
+  acl_ea_header* header = (acl_ea_header*)buf;
+  header->a_version = htole32(ACL_EA_VERSION);
+  acl_ea_entry* ext_entry = (acl_ea_entry*)(header + 1);
+  for (auto entry_it = entries.begin(); entry_it != entries.end(); ++entry_it) {
+    *ext_entry = *entry_it;
+    ext_entry += 1;
+  }
+
+  o_binary_acl = buf;
+  o_size = buf_size;
+  return 0;
+}
+
+#ifdef COMPARE_TO_LIBACL
+int acl_from_text_to_xattr_value_libacl(const string textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode)
+{
+  acl_t acl = acl_from_text(textual_acl.c_str());  // Convert ACL string to acl_t object
+  if (!acl) {
+    return EINVAL;
+  }
+  if (acl_valid(acl) != 0) {
+    acl_free(acl);
+    return EINVAL;
+  }
+
+  // check if the ACL string contains more than the synthetic ACLs
+  int equiv = acl_equiv_mode(acl, NULL);
+  assert(equiv != -1);
+
+  o_equiv_mode = equiv == 0;
+  if (!o_equiv_mode) {
+    o_binary_acl = (char *)acl_to_xattr(acl, &o_size);
+  } else {
+    o_binary_acl = NULL;
+    o_size = 0;
+  }
+  acl_free(acl);
+  return 0;
+}
+
+int acl_from_text_to_xattr_value_both_impl(const string textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode)
+{
+  struct impl_result {
+    int ret;
+    size_t binary_size;
+    char *binary_acl;
+    bool equiv_mode;
+  } b, l;
+  b.ret = acl_from_text_to_xattr_value(textual_acl, b.binary_acl, b.binary_size, b.equiv_mode);
+  l.ret = acl_from_text_to_xattr_value_libacl(textual_acl, l.binary_acl, l.binary_size, l.equiv_mode);
+  assert(b.ret == l.ret);
+  if (!l.ret) {
+    assert(b.binary_size == l.binary_size);
+    assert(0 == memcmp(b.binary_acl, l.binary_acl, b.binary_size));
+    assert(b.equiv_mode == l.equiv_mode);
+    free(l.binary_acl);
+  }
+  o_binary_acl = b.binary_acl;
+  o_size = b.binary_size;
+  o_equiv_mode = b.equiv_mode;
+  return b.ret;
+}
+#endif // COMPARE_TO_LIBACL

--- a/cvmfs/acl.h
+++ b/cvmfs/acl.h
@@ -1,0 +1,20 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#ifndef CVMFS_ACL_H_
+#define CVMFS_ACL_H_
+
+#include <inttypes.h>
+#include <stddef.h>
+#include <string>
+
+/* Takes textual ACL, outputs binary array fit to be a value of system.posix_acl_access */
+int acl_from_text_to_xattr_value(const std::string textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode);
+
+//#define COMPARE_TO_LIBACL
+#ifdef COMPARE_TO_LIBACL
+int acl_from_text_to_xattr_value_both_impl(const std::string textual_acl, char *&o_binary_acl, size_t &o_size, bool &o_equiv_mode);
+#endif // COMPARE_TO_LIBACL
+
+#endif  // CVMFS_ACL_H_

--- a/cvmfs/swissknife_ingestsql.cc
+++ b/cvmfs/swissknife_ingestsql.cc
@@ -17,7 +17,7 @@
 #include <unordered_set>
 #include <stack>
 
-#include "acl/libacl.h"
+#include "acl.h"
 #include "catalog_mgr_rw.h"
 #include "curl/curl.h"
 #include "gateway_util.h"
@@ -75,8 +75,7 @@ static vector<string> get_all_dirs_from_sqlite(vector<string>& sqlite_db_vec,
 static string get_parent(const string& path);
 static string get_basename(const string& path);
 
-//TODO(@vvolkl): figure out how to export acl_to_xattr
-//static XattrList marshal_xattrs(const char *acl);
+static XattrList marshal_xattrs(const char *acl);
 static string sanitise_name(const char *name_cstr, bool allow_leading_slash);
 static void on_signal(int sig);
 static string acquire_lease(const string& key_id, const string& secret, const string& lease_path,
@@ -389,32 +388,29 @@ static string get_lease_from_paths(vector<string> paths) {
   return prefix;
 }
 
-//TODO(@vvolkl): figure out how to export acl_to_xattr
-// Convert the human-readable ACL into the binary format used to store it in an
-// xattr.
-//static XattrList marshal_xattrs(const char *acl_string) {
-//  XattrList aclobj;
-//
-//  if (acl_string == NULL || strlen(acl_string) == 0) {
-//    return aclobj;
-//  }
-//
-//  acl_t acl = acl_from_text(acl_string);  // Convert ACL string to acl_t object
-//  CUSTOM_ASSERT(acl != NULL, "failed to parse ACL from string: %s", acl_string);
-//  CUSTOM_ASSERT(0 == acl_valid(acl), "parsed ACL failed acl_valid check");
-//  // check if the ACL string contains more than the synthetic ACLs
-//  int equiv = acl_equiv_mode(acl, NULL);
-//  CUSTOM_ASSERT(-1 != equiv, "error on acl_equiv_mode check");
-//  if (equiv == 1) {
-//    size_t binary_size;
-//    char *binary_acl = (char *)acl_to_xattr(acl, &binary_size);
-//    CUSTOM_ASSERT(aclobj.Set("system.posix_acl_access", string(binary_acl, binary_size)), "failed to set system.posix_acl_access (ACL size %lu)", binary_size);
-//    free(binary_acl);
-//  }
-//
-//  acl_free(acl);
-//  return aclobj;
-//}
+static XattrList marshal_xattrs(const char *acl_string) {
+  XattrList aclobj;
+
+  if (acl_string == NULL || acl_string[0] == '\0') {
+    return aclobj;
+  }
+
+  bool equiv_mode;
+  size_t binary_size;
+  char *binary_acl;
+  int ret = acl_from_text_to_xattr_value(string(acl_string), binary_acl, binary_size, equiv_mode);
+  if (ret) {
+    LogCvmfs(kLogCvmfs, kLogStderr, "failure of acl_from_text_to_xattr_value(%s)", acl_string);
+    assert(0); // TODO incorporate error handling other than asserting
+    return aclobj;
+  }
+  if (!equiv_mode) {
+    CUSTOM_ASSERT(aclobj.Set("system.posix_acl_access", string(binary_acl, binary_size)), "failed to set system.posix_acl_access (ACL size %d)", binary_size);
+    free(binary_acl);
+  }
+
+  return aclobj;
+}
 
 std::unordered_map<string, string> load_config(const string& config_file) {
   std::unordered_map<string, string> config_map;
@@ -1129,9 +1125,8 @@ void swissknife::IngestSQL::load_dirs(sqlite3 *db, const std::string &lease_path
     CUSTOM_ASSERT(check_prefix(name, lease_path), "%s is not below lease path %s", name.c_str(), lease_path.c_str());
 
     Directory dir(name, mtime, mode, owner, grp, nested);
-    //TODO(@vvolkl): figure out how to export acl_to_xattr
-    //char *acl = (char *)sqlite3_column_text(stmt, 5);
-    //dir.xattr = marshal_xattrs(acl);
+    char *acl = (char *)sqlite3_column_text(stmt, 5);
+    dir.xattr = marshal_xattrs(acl);
     all_dirs.insert(std::make_pair(name, dir));
   }
   CHECK_SQLITE_ERROR(sqlite3_finalize(stmt), SQLITE_OK);

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -285,6 +285,7 @@ set(CVMFS_UNITTEST_SOURCES
   ../common/testutil.cc
   ../common/catalog_test_tools.cc
 
+  t_acl.cc
   t_assert_or_log.cc
   t_atomic.cc
   t_authz_fetch.cc
@@ -402,6 +403,7 @@ set(CVMFS_UNITTEST_SOURCES
   t_wpad.cc
   t_xattr.cc
 
+  ${CVMFS_SOURCE_DIR}/acl.cc
   ${CVMFS_SOURCE_DIR}/authz/authz.cc
   ${CVMFS_SOURCE_DIR}/authz/authz_curl.cc
   ${CVMFS_SOURCE_DIR}/authz/authz_fetch.cc

--- a/test/unittests/t_acl.cc
+++ b/test/unittests/t_acl.cc
@@ -1,0 +1,198 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+
+#include <algorithm>
+
+#include <cerrno>
+#include <string>
+#include <gtest/gtest.h>
+
+#include "acl.h"
+
+using namespace std;  // NOLINT
+
+class T_Acl : public ::testing::Test {
+};
+
+// The function should return success.
+// But it shouldn't be expected to return exactly the same as libacl.
+static void should_pass_noncompat(const char *textual, unsigned char *acl_binary_expected, unsigned int acl_binary_expected_len)
+{
+  size_t binary_size;
+  char *binary_acl;
+  bool equiv_mode;
+  int ret = acl_from_text_to_xattr_value(string(textual), binary_acl, binary_size, equiv_mode);
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(binary_size, acl_binary_expected_len);
+  if (binary_size == 0) {
+    ASSERT_TRUE(equiv_mode);
+    ASSERT_EQ(binary_acl, nullptr);
+  } else {
+    ASSERT_FALSE(equiv_mode);
+    ASSERT_NE(binary_acl, nullptr);
+    ASSERT_EQ(0, memcmp(binary_acl, acl_binary_expected, binary_size));
+  }
+  free(binary_acl);
+}
+
+static void should_pass(const char *textual, unsigned char *acl_binary_expected, unsigned int acl_binary_expected_len)
+{
+  size_t binary_size;
+  char *binary_acl;
+  bool equiv_mode;
+#ifdef COMPARE_TO_LIBACL
+  int ret = acl_from_text_to_xattr_value_both_impl(string(textual), binary_acl, binary_size, equiv_mode);
+#else // COMPARE_TO_LIBACL
+  int ret = acl_from_text_to_xattr_value(string(textual), binary_acl, binary_size, equiv_mode);
+#endif // COMPARE_TO_LIBACL
+  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(binary_size, acl_binary_expected_len);
+  if (binary_size == 0) {
+    ASSERT_TRUE(equiv_mode);
+    ASSERT_EQ(binary_acl, nullptr);
+  } else {
+    ASSERT_FALSE(equiv_mode);
+    ASSERT_NE(binary_acl, nullptr);
+    ASSERT_EQ(0, memcmp(binary_acl, acl_binary_expected, binary_size));
+  }
+  free(binary_acl);
+}
+
+static void should_fail(const char *textual)
+{
+  size_t binary_size;
+  char *binary_acl;
+  bool equiv_mode;
+#ifdef COMPARE_TO_LIBACL
+  int ret = acl_from_text_to_xattr_value_both_impl(string(textual), binary_acl, binary_size, equiv_mode);
+#else // COMPARE_TO_LIBACL
+  int ret = acl_from_text_to_xattr_value(string(textual), binary_acl, binary_size, equiv_mode);
+#endif // COMPARE_TO_LIBACL
+  ASSERT_EQ(ret, EINVAL);
+}
+
+TEST_F(T_Acl, t1) {
+  const char *textual =
+    "user::rwx\n"
+    "group::r-x\n"
+    "group:root:rwx\n"
+    "group:1000:rwx\n"
+    "mask::rwx\n"
+    "other::---\n";
+
+  // setfacl --modify-file acl.txt /tmp/test
+  // getfattr --name=system.posix_acl_access  --only-values /tmp/test > acl_binary_expected
+  // xxd --include acl_binary_expected
+  unsigned char acl_binary_expected[] = {
+    0x02, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x07, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x04, 0x00, 0x05, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x08, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x08, 0x00, 0x07, 0x00, 0xe8, 0x03, 0x00, 0x00,
+    0x10, 0x00, 0x07, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x20, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff
+  };
+  unsigned int acl_binary_expected_len = 52;
+  should_pass(textual, acl_binary_expected, acl_binary_expected_len);
+}
+
+TEST_F(T_Acl, t2) {
+
+  // no required entries u::,g::,o::
+  should_fail("u::r");
+  should_fail("u:bin:rw");
+  should_fail("u:bin:rw,g::r,o::-");
+  should_fail("");
+  should_fail(",");
+  should_fail(",,");
+  should_fail("\n,");
+  should_fail(",\n");
+
+  // since u:name: entry is there, mask:: entry is required
+  should_fail("u:bin:rw,u::rw,g::r,o::-");
+
+  // setfacl does not produce system.posix_acl_access attribute in this case,
+  // because this ACL corresponds to simple mermissions mode expression.
+  // libacl's acl_from_text() returns EINVAL.
+  should_pass("u::rw,g::r,o::-", nullptr, 0);
+  should_pass("u::rw\ng::r\no::-\n", nullptr, 0);
+  should_pass("u::rw-,g::r--,o::---", nullptr, 0);
+
+  // excessive delimiters
+  should_pass_noncompat("u::rw,,g::r,,,o::-", nullptr, 0);
+  should_pass_noncompat("u::rw\ng::r,\no::-\n", nullptr, 0);
+  should_pass_noncompat("u::rw-,g::r--,o::---", nullptr, 0);
+
+  should_fail("u::-,u::rw,g::r,o::-"); // duplicate u::
+}
+
+TEST_F(T_Acl, t3) {
+  const char *textual = "u:bin:rw,u::rw,g::r,o::-,mask::rwx";
+  unsigned char acl_binary_expected[] = {
+    0x02, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x06, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x02, 0x00, 0x06, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x04, 0x00, 0x04, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x10, 0x00, 0x07, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x20, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff
+  };
+  unsigned int acl_binary_expected_len = 44;
+  should_pass(textual, acl_binary_expected, acl_binary_expected_len);
+}
+
+TEST_F(T_Acl, t5) {
+  const char *textual = "u::-,g::r,o::rwx,mask::rwx,u:bin:rw";
+  unsigned char acl_binary_expected[] = {
+    0x02, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x02, 0x00, 0x06, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x04, 0x00, 0x04, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x10, 0x00, 0x07, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x20, 0x00, 0x07, 0x00, 0xff, 0xff, 0xff, 0xff
+  };
+
+  unsigned int acl_binary_expected_len = 44;
+  should_pass(textual, acl_binary_expected, acl_binary_expected_len);
+}
+
+TEST_F(T_Acl, t6) {
+  const char *textual = "u:bin:rw,u:daemon:r,u::-,g::-,o::-,m::-";
+  unsigned char acl_binary_expected[] = {
+    0x02, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x02, 0x00, 0x06, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x02, 0x00, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00,
+    0x04, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x10, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x20, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff
+  };
+  unsigned int acl_binary_expected_len = 52;
+  should_pass(textual, acl_binary_expected, acl_binary_expected_len);
+}
+
+TEST_F(T_Acl, t8) {
+  // our code doesn't support "d(efault):tag:id:perm" and doesn't need to.
+  const char *textual = "u:bin:rwx,u:daemon:rw,d:u:bin:rwx,d:m:rx,u::-,g::-,o::-,m::-";
+  size_t binary_size;
+  char *binary_acl;
+  bool equiv_mode;
+  int ret = acl_from_text_to_xattr_value(string(textual), binary_acl, binary_size, equiv_mode);
+  ASSERT_EQ(ret, EINVAL);
+}
+
+TEST_F(T_Acl, t9) {
+  const char *textual = "u:daemon:rx,g:root:rx,g:daemon:rwx,u::-,g::-,o::-,m::-";
+  unsigned char acl_binary_expected[] = {
+    0x02, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x02, 0x00, 0x05, 0x00, 0x02, 0x00, 0x00, 0x00,
+    0x04, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x08, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x08, 0x00, 0x07, 0x00, 0x02, 0x00, 0x00, 0x00,
+    0x10, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+    0x20, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff
+  };
+  unsigned int acl_binary_expected_len = 60;
+  should_pass(textual, acl_binary_expected, acl_binary_expected_len);
+}


### PR DESCRIPTION
Up to now, the upcoming swissknife_ingestsql tool uses libacl (from "acl" project) to convert ACL metadata from textual to xattr form.

But libacl does not export appropriate function.
For now a workaround of patching a bundled libacl was employed. The functionality works, but dependency bundling can create friction to adoption by some Linux distributions.

The needed patch was sent to the mailing list of acl package, but in the last 1.5 months, it hasn't received any reaction.
https://lists.nongnu.org/archive/html/acl-devel/2025-04/msg00000.html

Exactly the same technical change was considered in 2018, but nothing was changed: https://mail.gnu.org/archive/html/acl-devel/2018-02/msg00004.html

This changeset does not remove libacl dependency from the build system, this will have to be done in a separate commit.

This changeset includes both the implementation and the tests. Tests are based on reference output which is incorporated into the test source code. For most of the test cases, the new implementation returns exactly the same binary output and return code as the old one.

The new unittests module has a compile time option (disabled by default) to run both new implementation and libacl functions on the test cases and to compare their results. To enable this:

- uncomment `#define COMPARE_TO_LIBACL` in cvmfs/acl.h
- add `${LIBACL_LIBRARY}` to CVMFS_UNITTESTS_LINK_LIBRARIES in test/unittests/CMakeLists.txt